### PR TITLE
콘서트 예약 가능한 날짜 조회 API

### DIFF
--- a/src/main/kotlin/dev/concert/application/concert/facade/ConcertFacade.kt
+++ b/src/main/kotlin/dev/concert/application/concert/facade/ConcertFacade.kt
@@ -1,5 +1,6 @@
 package dev.concert.application.concert.facade
 
+import dev.concert.application.concert.dto.ConcertDatesDto
 import dev.concert.application.concert.dto.ConcertsDto
 import dev.concert.application.concert.service.ConcertService
 import org.springframework.stereotype.Service
@@ -10,5 +11,9 @@ class ConcertFacade (
 ){
     fun getConcerts(): List<ConcertsDto> {
         return concertService.getConcerts()
+    }
+
+    fun getAvailableDates(concertId: Long): List<ConcertDatesDto> {
+        return concertService.getAvailableDates(concertId)
     }
 }

--- a/src/main/kotlin/dev/concert/application/concert/service/ConcertServiceImpl.kt
+++ b/src/main/kotlin/dev/concert/application/concert/service/ConcertServiceImpl.kt
@@ -1,5 +1,6 @@
 package dev.concert.application.concert.service
 
+import dev.concert.application.concert.dto.ConcertDatesDto
 import dev.concert.application.concert.dto.ConcertsDto
 import dev.concert.domain.ConcertRepository
 import org.springframework.stereotype.Service
@@ -18,5 +19,16 @@ class ConcertServiceImpl (
             reserveStartDate = it.reserveStartDate,
             reserveEndDate = it.reserveEndDate,
         ) }
+    }
+
+    override fun getAvailableDates(concertId: Long): List<ConcertDatesDto> {
+        return concertRepository.getAvailableDates(concertId).map { ConcertDatesDto(
+            concertId = it.concert.id,
+            concertName = it.concert.concertName,
+            availableSeats = it.availableSeats,
+            concertTime = it.concertTime,
+            concertVenue = it.concertVenue,
+            concertDate = it.concertDate,
+        )}
     }
 }

--- a/src/main/kotlin/dev/concert/config/FilterConfig.kt
+++ b/src/main/kotlin/dev/concert/config/FilterConfig.kt
@@ -14,7 +14,7 @@ class FilterConfig (
     fun tokenFilterRegistration(): FilterRegistrationBean<TokenValidateFilter> {
         val registrationBean = FilterRegistrationBean<TokenValidateFilter>()
         registrationBean.filter = tokenValidateFilter
-        registrationBean.addUrlPatterns("/queue/tokens/status", "/concerts")
+        registrationBean.addUrlPatterns("/queue/tokens/status", "/concerts/*")
         return registrationBean
     }
 }

--- a/src/main/kotlin/dev/concert/infrastructure/ConcertRepositoryImpl.kt
+++ b/src/main/kotlin/dev/concert/infrastructure/ConcertRepositoryImpl.kt
@@ -2,14 +2,21 @@ package dev.concert.infrastructure
 
 import dev.concert.domain.ConcertRepository
 import dev.concert.domain.entity.ConcertEntity
+import dev.concert.domain.entity.ConcertOptionEntity
 import dev.concert.infrastructure.jpa.ConcertJpaRepository
+import dev.concert.infrastructure.jpa.ConcertOptionJpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
 class ConcertRepositoryImpl (
-    private val concertJpaRepository: ConcertJpaRepository
+    private val concertJpaRepository: ConcertJpaRepository,
+    private val concertOptionJpaRepository: ConcertOptionJpaRepository,
 ) : ConcertRepository {
     override fun getConcerts(): List<ConcertEntity> {
         return concertJpaRepository.findAllByStartDateAfter()
+    }
+
+    override fun getAvailableDates(concertId: Long): List<ConcertOptionEntity> {
+        return concertOptionJpaRepository.findAvailableDates(concertId)
     }
 }

--- a/src/main/kotlin/dev/concert/infrastructure/jpa/ConcertOptionJpaRepository.kt
+++ b/src/main/kotlin/dev/concert/infrastructure/jpa/ConcertOptionJpaRepository.kt
@@ -1,0 +1,22 @@
+package dev.concert.infrastructure.jpa
+
+import dev.concert.domain.entity.ConcertOptionEntity
+import dev.concert.domain.entity.QConcertEntity.concertEntity
+import dev.concert.domain.entity.QConcertOptionEntity.concertOptionEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
+
+interface ConcertOptionJpaRepository : JpaRepository<ConcertOptionEntity, Long> , ConcertOptionJpaRepositoryCustom
+
+interface ConcertOptionJpaRepositoryCustom {
+    fun findAvailableDates(concertId: Long): List<ConcertOptionEntity>
+}
+
+class ConcertOptionJpaRepositoryImpl : ConcertOptionJpaRepositoryCustom, QuerydslRepositorySupport(ConcertOptionEntity::class.java) {
+    override fun findAvailableDates(concertId: Long): List<ConcertOptionEntity> {
+        return from(concertOptionEntity)
+            .join(concertOptionEntity.concert, concertEntity).fetchJoin()
+            .where(concertOptionEntity.concert.id.eq(concertId))
+            .fetch()
+    }
+}

--- a/src/main/kotlin/dev/concert/presentation/ConcertController.kt
+++ b/src/main/kotlin/dev/concert/presentation/ConcertController.kt
@@ -2,8 +2,13 @@ package dev.concert.presentation
 
 import dev.concert.ApiResult
 import dev.concert.application.concert.facade.ConcertFacade
+import dev.concert.presentation.response.concert.ConcertAvailableDatesResponse
 import dev.concert.presentation.response.concert.ConcertsResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -17,5 +22,17 @@ class ConcertController (
     fun getConcerts(): ApiResult<ConcertsResponse> {
         val concerts = concertFacade.getConcerts()
         return ApiResult(data = ConcertsResponse(concerts))
+    }
+
+    @Operation(summary = "콘서트 날짜 조회 API", description = "콘서트의 예약 가능한 날짜를 조회합니다.")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "콘서트 날짜 조회 성공"),
+    )
+    @GetMapping("/{concertId}/available-dates")
+    fun getAvailableDates(
+        @PathVariable concertId: Long,
+    ): ApiResult<ConcertAvailableDatesResponse> {
+        val dates = concertFacade.getAvailableDates(concertId)
+        return ApiResult(data = ConcertAvailableDatesResponse(dates))
     }
 }

--- a/src/test/kotlin/dev/concert/application/concert/service/ConcertServiceImplTest.kt
+++ b/src/test/kotlin/dev/concert/application/concert/service/ConcertServiceImplTest.kt
@@ -1,8 +1,8 @@
 package dev.concert.application.concert.service
 
-import dev.concert.application.concert.dto.ConcertsDto
 import dev.concert.domain.ConcertRepository
 import dev.concert.domain.entity.ConcertEntity
+import dev.concert.domain.entity.ConcertOptionEntity
 import org.junit.jupiter.api.Test
 
 import org.junit.jupiter.api.Assertions.*
@@ -52,5 +52,45 @@ class ConcertServiceImplTest {
         assertEquals(concertList.size, concerts.size)
         assertEquals(concertList[0].concertName, concerts[0].concertName)
         assertEquals(concertList[0].singer, concerts[0].singer)
+    }
+
+    @Test
+    fun `콘서트 예약 가능한 날짜를 조회한다`() {
+        // given
+        val concertId = 1L
+        val concert = ConcertEntity(
+            concertName = "새해 콘서트",
+            singer = "에스파",
+            startDate = "20241201",
+            endDate = "20241201",
+            reserveStartDate = "20241201",
+            reserveEndDate = "20241201"
+        )
+        val concertOptions = listOf(
+            ConcertOptionEntity(
+                concert = concert,
+                availableSeats = 50,
+                concertTime = "14:00",
+                concertVenue = "올림픽공원",
+                concertDate = "20241201"
+            ),
+            ConcertOptionEntity(
+                concert = concert,
+                availableSeats = 50,
+                concertTime = "14:00",
+                concertVenue = "올림픽공원",
+                concertDate = "20241202"
+            )
+        )
+
+        given(concertRepository.getAvailableDates(concertId)).willReturn(concertOptions)
+
+        // when
+        val availableDates = concertService.getAvailableDates(concertId)
+
+        // then
+        assertEquals(2, availableDates.size)
+        assertEquals("20241201", availableDates[0].concertDate)
+        assertEquals("20241202", availableDates[1].concertDate)
     }
 }


### PR DESCRIPTION
# 콘서트 예약 가능한 날짜 조회 API

하나의 콘서트에 연결된 콘서트 시간 데이터를 가져옵니다
querydsl 을 사용해서 fetchJoin 으로 한번의 쿼리에 데이터를 가져오도록 구현했습니다

Concert - ConcertOption