### PR TITLE
토큰 발급 조회 API

### DIFF
--- a/src/main/kotlin/dev/concert/application/token/TokenFacade.kt
+++ b/src/main/kotlin/dev/concert/application/token/TokenFacade.kt
@@ -1,6 +1,7 @@
 package dev.concert.application.token
 
 import dev.concert.application.token.dto.TokenResponseDto
+import dev.concert.application.token.dto.TokenValidationResult
 import org.springframework.stereotype.Service
 
 @Service 
@@ -9,11 +10,7 @@ class TokenFacade (
 ){ 
     fun generateToken(userId: Long): String { 
         return tokenService.generateToken(userId) 
-    } 
- 
-    fun isTokenExpired(token: String): Boolean { 
-        return tokenService.isTokenExpired(token) 
-    } 
+    }
  
     fun getToken(token: String): TokenResponseDto { 
         return tokenService.getToken(token) 
@@ -21,9 +18,9 @@ class TokenFacade (
  
     fun manageTokenStatus() { 
         tokenService.manageTokenStatus() 
-    } 
+    }
 
-    fun isAvailableToken(token: String): Boolean { 
-        return tokenService.isAvailableToken(token) 
-    } 
+    fun validateToken(token: String): TokenValidationResult {
+        return tokenService.validateToken(token)
+    }
 }

--- a/src/main/kotlin/dev/concert/application/token/TokenFacade.kt
+++ b/src/main/kotlin/dev/concert/application/token/TokenFacade.kt
@@ -3,27 +3,27 @@ package dev.concert.application.token
 import dev.concert.application.token.dto.TokenResponseDto
 import org.springframework.stereotype.Service
 
-@Service
-class TokenFacade (
-    private val tokenService: TokenService,
-){
-    fun generateToken(userId: Long): String {
-        return tokenService.generateToken(userId)
-    }
+@Service 
+class TokenFacade ( 
+    private val tokenService: TokenService, 
+){ 
+    fun generateToken(userId: Long): String { 
+        return tokenService.generateToken(userId) 
+    } 
+ 
+    fun isTokenExpired(token: String): Boolean { 
+        return tokenService.isTokenExpired(token) 
+    } 
+ 
+    fun getToken(token: String): TokenResponseDto { 
+        return tokenService.getToken(token) 
+    } 
+ 
+    fun manageTokenStatus() { 
+        tokenService.manageTokenStatus() 
+    } 
 
-    fun isTokenExpired(token: String): Boolean {
-        return tokenService.isTokenExpired(token)
-    }
-
-    fun getToken(token: String): TokenResponseDto {
-        return tokenService.getToken(token)
-    }
-
-    fun manageTokenStatus() {
-        tokenService.manageTokenStatus()
-    }
-
-    fun isAvailableToken(token: String): Boolean {
-        return tokenService.isAvailableToken(token)
-    }
+    fun isAvailableToken(token: String): Boolean { 
+        return tokenService.isAvailableToken(token) 
+    } 
 }

--- a/src/main/kotlin/dev/concert/application/token/TokenService.kt
+++ b/src/main/kotlin/dev/concert/application/token/TokenService.kt
@@ -1,13 +1,13 @@
 package dev.concert.application.token
 
 import dev.concert.application.token.dto.TokenResponseDto
+import dev.concert.application.token.dto.TokenValidationResult
 import dev.concert.domain.entity.UserEntity
 
 interface TokenService {
     fun generateToken(userId: Long): String
-    fun isTokenExpired(token: String): Boolean
     fun getToken(token: String): TokenResponseDto
     fun deleteToken(user : UserEntity)
     fun manageTokenStatus()
-    fun isAvailableToken(token: String): Boolean
+    fun validateToken(token: String): TokenValidationResult
 }

--- a/src/main/kotlin/dev/concert/application/token/dto/TokenValidationResult.kt
+++ b/src/main/kotlin/dev/concert/application/token/dto/TokenValidationResult.kt
@@ -1,0 +1,8 @@
+package dev.concert.application.token.dto
+
+enum class TokenValidationResult {
+    VALID,
+    INVALID,
+    EXPIRED,
+    NOT_AVAILABLE
+}

--- a/src/main/kotlin/dev/concert/config/FilterConfig.kt
+++ b/src/main/kotlin/dev/concert/config/FilterConfig.kt
@@ -5,16 +5,16 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
-@Configuration
+//@Configuration
 class FilterConfig (
     private val tokenValidateFilter: TokenValidateFilter,
 ) {
 
-    @Bean
-    fun tokenFilterRegistration(): FilterRegistrationBean<TokenValidateFilter> {
-        val registrationBean = FilterRegistrationBean<TokenValidateFilter>()
-        registrationBean.filter = tokenValidateFilter
-        registrationBean.addUrlPatterns("/concerts/*", "/payment/*")
-        return registrationBean
-    }
+//    @Bean
+//    fun tokenFilterRegistration(): FilterRegistrationBean<TokenValidateFilter> {
+//        val registrationBean = FilterRegistrationBean<TokenValidateFilter>()
+//        registrationBean.filter = tokenValidateFilter
+//        registrationBean.addUrlPatterns("/concerts/*", "/payment/*")
+//        return registrationBean
+//    }
 }

--- a/src/main/kotlin/dev/concert/config/InterceptorConfig.kt
+++ b/src/main/kotlin/dev/concert/config/InterceptorConfig.kt
@@ -12,6 +12,6 @@ class InterceptorConfig (
 
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry.addInterceptor(tokenValidateInterceptor)
-            .addPathPatterns("/concerts/*", "/payment/*")
+            .addPathPatterns("/concerts/**", "/payment/**")
     }
 }

--- a/src/main/kotlin/dev/concert/config/InterceptorConfig.kt
+++ b/src/main/kotlin/dev/concert/config/InterceptorConfig.kt
@@ -1,0 +1,17 @@
+package dev.concert.config
+
+import dev.concert.presentation.interceptor.TokenValidateInterceptor
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class InterceptorConfig (
+    private val tokenValidateInterceptor: TokenValidateInterceptor,
+) : WebMvcConfigurer {
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(tokenValidateInterceptor)
+            .addPathPatterns("/concerts/*", "/payment/*")
+    }
+}

--- a/src/main/kotlin/dev/concert/domain/entity/QueueTokenEntity.kt
+++ b/src/main/kotlin/dev/concert/domain/entity/QueueTokenEntity.kt
@@ -24,7 +24,7 @@ class QueueTokenEntity (
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id : Long = 0
+    val id: Long = 0
 
     @Column(nullable = false)
     var token: String = token
@@ -32,7 +32,7 @@ class QueueTokenEntity (
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
-    var user : UserEntity = user
+    var user: UserEntity = user
         protected set
 
     // 만료 시간은 1시간으로 설정
@@ -50,5 +50,17 @@ class QueueTokenEntity (
 
     fun changeStatusExpired() {
         this.status = QueueTokenStatus.EXPIRED
+    }
+
+    fun isExpired(): Boolean {
+        if (this.expiresAt.isBefore(LocalDateTime.now())) {
+            this.changeStatusExpired()
+            return true
+        }
+        return false
+    }
+
+    fun isAvailable(): Boolean {
+        return this.status == QueueTokenStatus.ACTIVE
     }
 }

--- a/src/main/kotlin/dev/concert/infrastructure/TokenRepositoryImpl.kt
+++ b/src/main/kotlin/dev/concert/infrastructure/TokenRepositoryImpl.kt
@@ -7,35 +7,35 @@ import dev.concert.domain.entity.status.QueueTokenStatus
 import dev.concert.infrastructure.jpa.TokenJpaRepository
 import org.springframework.stereotype.Repository
 
-@Repository
-class TokenRepositoryImpl(
-    private val tokenJpaRepository: TokenJpaRepository
-) : TokenRepository {
-
-    override fun saveToken(tokenEntity: QueueTokenEntity): QueueTokenEntity {
-        return tokenJpaRepository.save(tokenEntity)
-    }
-
-    override fun findFirstQueueOrderId(): Long {
-        tokenJpaRepository.findFirstIdInQueueOrderStatusWating(QueueTokenStatus.WAITING)?.let{
-            return it.id
-        }
-        return 0
-    }
-
-    override fun findByToken(token: String): QueueTokenEntity? {
-        return tokenJpaRepository.findByToken(token)
-    }
-
-    override fun deleteToken(user: UserEntity) {
-        tokenJpaRepository.deleteByUser(user)
-    }
-
-    override fun findWaitingAndActiveTokens(): List<QueueTokenEntity> {
-        return tokenJpaRepository.findAvaliableTokens()
-    }
-
-    override fun deleteByToken(tokenEntity: QueueTokenEntity) {
-        tokenJpaRepository.delete(tokenEntity)
-    }
+@Repository 
+class TokenRepositoryImpl( 
+    private val tokenJpaRepository: TokenJpaRepository 
+) : TokenRepository { 
+ 
+    override fun saveToken(tokenEntity: QueueTokenEntity): QueueTokenEntity { 
+        return tokenJpaRepository.save(tokenEntity) 
+    } 
+ 
+    override fun findFirstQueueOrderId(): Long { 
+        tokenJpaRepository.findFirstIdInQueueOrderStatusWating(QueueTokenStatus.WAITING)?.let{ 
+            return it.id 
+        } 
+        return 0 
+    } 
+ 
+    override fun findByToken(token: String): QueueTokenEntity? { 
+        return tokenJpaRepository.findByToken(token) 
+    } 
+ 
+    override fun deleteToken(user: UserEntity) { 
+        tokenJpaRepository.deleteByUser(user) 
+    } 
+ 
+    override fun findWaitingAndActiveTokens(): List<QueueTokenEntity> { 
+        return tokenJpaRepository.findAvaliableTokens() 
+    } 
+ 
+    override fun deleteByToken(tokenEntity: QueueTokenEntity) { 
+        tokenJpaRepository.delete(tokenEntity) 
+    } 
 }

--- a/src/main/kotlin/dev/concert/presentation/TokenController.kt
+++ b/src/main/kotlin/dev/concert/presentation/TokenController.kt
@@ -47,8 +47,13 @@ class TokenController (
     ) 
     @GetMapping("/status") 
     fun getToken( 
-        @RequestHeader(HttpHeaders.AUTHORIZATION) token: String 
-    ) : ApiResult<TokenInfoResponse> { 
-        return ApiResult(TokenInfoResponse.from(tokenFacade.getToken(token))) 
-    } 
+        @RequestHeader(HttpHeaders.AUTHORIZATION) authorizationHeader: String
+    ) : ApiResult<TokenInfoResponse> {
+        val token = getBearerToken(authorizationHeader)
+        return ApiResult(TokenInfoResponse.from(tokenFacade.getToken(token)))
+    }
+
+    fun getBearerToken(authorizationHeader: String): String {
+        return authorizationHeader.substring(7)
+    }
 }

--- a/src/main/kotlin/dev/concert/presentation/TokenController.kt
+++ b/src/main/kotlin/dev/concert/presentation/TokenController.kt
@@ -20,35 +20,35 @@ import org.springframework.web.bind.annotation.RestController
 @Tag(name = "토큰 발급 API", description = "토큰 발급 API를 제공합니다")
 @RestController
 @RequestMapping("/queue/tokens")
-class TokenController (
-    private val tokenFacade: TokenFacade,
-) {
-
-    @Operation(
-        summary = "토큰 발급 API",
-        description = "유저 아이디를 받아 토큰을 발급합니다",
-    )
-    @ApiResponses(
+class TokenController ( 
+    private val tokenFacade: TokenFacade, 
+) { 
+ 
+    @Operation( 
+        summary = "토큰 발급 API", 
+        description = "유저 아이디를 받아 토큰을 발급합니다", 
+    ) 
+    @ApiResponses( 
         ApiResponse(responseCode = "200", description = "토큰 발급 성공"),
-    )
-    @PostMapping
-    fun createToken(
-        @RequestBody tokenRequest: TokenRequest
-    ) : ApiResult<TokenResponse> {
-        return ApiResult(TokenResponse.of(tokenFacade.generateToken(tokenRequest.userId)))
-    }
-
-    @Operation(
-        summary = "토큰 조회 API",
-        description = "토큰을 조회합니다",
-    )
-    @ApiResponses(
-        ApiResponse(responseCode = "200", description = "토큰 조회 성공"),
-    )
-    @GetMapping("/status")
-    fun getToken(
-        @RequestHeader(HttpHeaders.AUTHORIZATION) token: String
-    ) : ApiResult<TokenInfoResponse> {
-        return ApiResult(TokenInfoResponse.from(tokenFacade.getToken(token)))
-    }
+    )  
+    @PostMapping 
+    fun createToken( 
+        @RequestBody tokenRequest: TokenRequest 
+    ) : ApiResult<TokenResponse> { 
+        return ApiResult(TokenResponse.of(tokenFacade.generateToken(tokenRequest.userId))) 
+    } 
+ 
+    @Operation( 
+        summary = "토큰 조회 API", 
+        description = "토큰을 조회합니다", 
+    ) 
+    @ApiResponses( 
+        ApiResponse(responseCode = "200", description = "토큰 조회 성공"), 
+    ) 
+    @GetMapping("/status") 
+    fun getToken( 
+        @RequestHeader(HttpHeaders.AUTHORIZATION) token: String 
+    ) : ApiResult<TokenInfoResponse> { 
+        return ApiResult(TokenInfoResponse.from(tokenFacade.getToken(token))) 
+    } 
 }

--- a/src/main/kotlin/dev/concert/presentation/filter/TokenValidateFilter.kt
+++ b/src/main/kotlin/dev/concert/presentation/filter/TokenValidateFilter.kt
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 
-@Component 
+//@Component
 class TokenValidateFilter ( 
     private val tokenFacade: TokenFacade, 
 ) : OncePerRequestFilter() { 

--- a/src/main/kotlin/dev/concert/presentation/filter/TokenValidateFilter.kt
+++ b/src/main/kotlin/dev/concert/presentation/filter/TokenValidateFilter.kt
@@ -1,6 +1,7 @@
 package dev.concert.presentation.filter
 
 import dev.concert.application.token.TokenFacade
+import dev.concert.application.token.dto.TokenValidationResult
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -15,20 +16,22 @@ class TokenValidateFilter (
 ) : OncePerRequestFilter() { 
  
     override fun doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain) { 
-        val token = getBearerToken(request) 
-        if (token == null) { 
-            response.sendError(HttpStatus.UNAUTHORIZED.value(), "토큰이 없습니다") 
-            return 
-        }else if (tokenFacade.isTokenExpired(token)) { 
-            response.sendError(HttpStatus.UNAUTHORIZED.value(), "토큰이 만료되었습니다") 
-            return 
-        } else if(!tokenFacade.isAvailableToken(token)){ 
-            response.sendError(HttpStatus.UNAUTHORIZED.value(), "대기열 순번 확인이 필요합니다") 
-            return 
-        } 
-        filterChain.doFilter(request, response) 
-    } 
- 
+        val token = getBearerToken(request) ?: run {
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), "토큰이 없습니다")
+            return
+        }
+        logger.info("token: $token")
+
+        val validateResult = tokenFacade.validateToken(token)
+
+        when (validateResult) {
+            TokenValidationResult.EXPIRED -> return response.sendError(HttpStatus.UNAUTHORIZED.value(), "토큰이 만료되었습니다")
+            TokenValidationResult.NOT_AVAILABLE -> return response.sendError(HttpStatus.UNAUTHORIZED.value(), "대기열 순번 확인이 필요합니다")
+            TokenValidationResult.INVALID -> return response.sendError(HttpStatus.UNAUTHORIZED.value(), "유효하지 않은 토큰입니다")
+            TokenValidationResult.VALID -> filterChain.doFilter(request, response)
+        }
+    }
+
     private fun getBearerToken(request: HttpServletRequest): String? { 
         val header = request.getHeader(HttpHeaders.AUTHORIZATION) 
         return if (header != null && header.startsWith("Bearer ")) { 

--- a/src/main/kotlin/dev/concert/presentation/filter/TokenValidateFilter.kt
+++ b/src/main/kotlin/dev/concert/presentation/filter/TokenValidateFilter.kt
@@ -9,33 +9,32 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 
-@Component
-class TokenValidateFilter (
-    private val tokenFacade: TokenFacade,
-) : OncePerRequestFilter() {
-
-    override fun doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain) {
-        val token = getBearerToken(request)
-        print("token: $token")
-        if (token == null) {
-            response.sendError(HttpStatus.UNAUTHORIZED.value(), "토큰이 없습니다")
-            return
-        }else if (tokenFacade.isTokenExpired(token)) {
-            response.sendError(HttpStatus.UNAUTHORIZED.value(), "토큰이 만료되었습니다")
-            return
-        } else if(!tokenFacade.isAvailableToken(token)){
-            response.sendError(HttpStatus.UNAUTHORIZED.value(), "대기열 순번 확인이 필요합니다")
-            return
-        }
-        filterChain.doFilter(request, response)
-    }
-
-    private fun getBearerToken(request: HttpServletRequest): String? {
-        val header = request.getHeader(HttpHeaders.AUTHORIZATION)
-        return if (header != null && header.startsWith("Bearer ")) {
-            header.substring(7)
-        } else {
-            null
-        }
-    }
-}
+@Component 
+class TokenValidateFilter ( 
+    private val tokenFacade: TokenFacade, 
+) : OncePerRequestFilter() { 
+ 
+    override fun doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain) { 
+        val token = getBearerToken(request) 
+        if (token == null) { 
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), "토큰이 없습니다") 
+            return 
+        }else if (tokenFacade.isTokenExpired(token)) { 
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), "토큰이 만료되었습니다") 
+            return 
+        } else if(!tokenFacade.isAvailableToken(token)){ 
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), "대기열 순번 확인이 필요합니다") 
+            return 
+        } 
+        filterChain.doFilter(request, response) 
+    } 
+ 
+    private fun getBearerToken(request: HttpServletRequest): String? { 
+        val header = request.getHeader(HttpHeaders.AUTHORIZATION) 
+        return if (header != null && header.startsWith("Bearer ")) { 
+            header.substring(7) 
+        } else { 
+            null 
+        } 
+    } 
+} 

--- a/src/main/kotlin/dev/concert/presentation/interceptor/TokenValidateInterceptor.kt
+++ b/src/main/kotlin/dev/concert/presentation/interceptor/TokenValidateInterceptor.kt
@@ -1,0 +1,57 @@
+package dev.concert.presentation.interceptor
+
+import dev.concert.application.token.TokenFacade
+import dev.concert.application.token.dto.TokenValidationResult
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+
+@Component
+class TokenValidateInterceptor (
+    private val tokenFacade: TokenFacade,
+) : HandlerInterceptor {
+
+    private val logger: Logger = LoggerFactory.getLogger(TokenValidateInterceptor::class.java)
+
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        val token = getBearerToken(request) ?: run {
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), "토큰이 없습니다")
+            return false
+        }
+
+        val validateResult = tokenFacade.validateToken(token)
+
+        return when (validateResult) {
+            TokenValidationResult.EXPIRED -> {
+                logger.warn("만료된 토큰입니다 : $token")
+                response.sendError(HttpStatus.UNAUTHORIZED.value(), "토큰이 만료되었습니다")
+                false
+            }
+            TokenValidationResult.NOT_AVAILABLE -> {
+                logger.warn("대기열 순번 확인이 필요한 토큰입니다 : $token")
+                response.sendError(HttpStatus.UNAUTHORIZED.value(), "대기열 순번 확인이 필요합니다")
+                false
+            }
+            TokenValidationResult.INVALID -> {
+                logger.warn("유효하지 않은 토큰입니다 : $token")
+                response.sendError(HttpStatus.UNAUTHORIZED.value(), "유효하지 않은 토큰입니다")
+                false
+            }
+            TokenValidationResult.VALID -> true
+        }
+    }
+
+    private fun getBearerToken(request: HttpServletRequest): String? {
+        val header = request.getHeader(HttpHeaders.AUTHORIZATION)
+        return if (header != null && header.startsWith("Bearer ")) {
+            header.substring(7)
+        } else {
+            null
+        }
+    }
+}

--- a/src/test/kotlin/dev/concert/application/token/TokenIntegrationTest.kt
+++ b/src/test/kotlin/dev/concert/application/token/TokenIntegrationTest.kt
@@ -9,7 +9,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
 
 @Transactional
-@SpringBootTest
+@SpringBootTest 
 class TokenIntegrationTest {
 
     @Autowired
@@ -18,38 +18,38 @@ class TokenIntegrationTest {
     @Autowired
     private lateinit var userService: UserService
 
-    @Test
-    fun `userId 로 토큰을 암호화 하여 발급한다`() {
-        val user = userService.saveUser(UserEntity("변주환"))
+    @Test 
+    fun `userId 로 토큰을 암호화 하여 발급한다`() { 
+        val user = userService.saveUser(UserEntity("변주환")) 
+ 
+        // when 
+        val generateToken = tokenFacade.generateToken(user.id) 
+ 
+        // then 
+        assertThat(generateToken).isNotBlank() 
+    } 
 
-        // when
-        val generateToken = tokenFacade.generateToken(user.id)
+    @Test 
+    fun `발급된 토큰의 유효시간 보다 현재시간이 전이면 TRUE 를 반환한다`() { 
+        val user = userService.saveUser(UserEntity("변주환")) 
+        val token = tokenFacade.generateToken(user.id) 
+ 
+        // when 
+        val isTokenAllowed = tokenFacade.isTokenExpired(token) 
+ 
+        // then 
+        assertThat(isTokenAllowed).isFalse() 
+    } 
 
-        // then
-        assertThat(generateToken).isNotBlank()
-    }
-
-    @Test
-    fun `발급된 토큰의 유효시간 보다 현재시간이 전이면 TRUE 를 반환한다`() {
-        val user = userService.saveUser(UserEntity("변주환"))
-        val token = tokenFacade.generateToken(user.id)
-
-        // when
-        val isTokenAllowed = tokenFacade.isTokenExpired(token)
-
-        // then
-        assertThat(isTokenAllowed).isFalse()
-    }
-
-    @Test
-    fun `현재 토큰정보를 반환한다 `() {
-        val user = userService.saveUser(UserEntity("변주환"))
-        val token = tokenFacade.generateToken(user.id)
-
-        // when
-        val tokenResponseDto = tokenFacade.getToken(token)
-
-        // then
-        assertThat(tokenResponseDto.token).isEqualTo(token)
-    }
-}
+    @Test 
+    fun `현재 토큰정보를 반환한다 `() { 
+        val user = userService.saveUser(UserEntity("변주환")) 
+        val token = tokenFacade.generateToken(user.id) 
+ 
+        // when 
+        val tokenResponseDto = tokenFacade.getToken(token) 
+ 
+        // then 
+        assertThat(tokenResponseDto.token).isEqualTo(token) 
+    } 
+} 

--- a/src/test/kotlin/dev/concert/application/token/TokenIntegrationTest.kt
+++ b/src/test/kotlin/dev/concert/application/token/TokenIntegrationTest.kt
@@ -1,5 +1,6 @@
 package dev.concert.application.token
 
+import dev.concert.application.token.dto.TokenValidationResult
 import dev.concert.application.user.UserService
 import dev.concert.domain.entity.UserEntity
 import org.assertj.core.api.Assertions.*
@@ -30,15 +31,16 @@ class TokenIntegrationTest {
     } 
 
     @Test 
-    fun `발급된 토큰의 유효시간 보다 현재시간이 전이면 TRUE 를 반환한다`() { 
+    fun `발급된 토큰의 유효시간 보다 현재시간이 전이면 유요한 토큰 상태를 반환한다`() {
         val user = userService.saveUser(UserEntity("변주환")) 
         val token = tokenFacade.generateToken(user.id) 
  
-        // when 
-        val isTokenAllowed = tokenFacade.isTokenExpired(token) 
+        // when
+        tokenFacade.manageTokenStatus()
+        val tokenResult = tokenFacade.validateToken(token)
  
         // then 
-        assertThat(isTokenAllowed).isFalse() 
+        assertThat(tokenResult).isEqualTo(TokenValidationResult.VALID)
     } 
 
     @Test 

--- a/src/test/kotlin/dev/concert/application/token/TokenServiceImplTest.kt
+++ b/src/test/kotlin/dev/concert/application/token/TokenServiceImplTest.kt
@@ -1,9 +1,11 @@
 package dev.concert.application.token
 
+import dev.concert.application.token.dto.TokenValidationResult
 import dev.concert.domain.TokenRepository
 import dev.concert.domain.UserRepository
 import dev.concert.domain.entity.QueueTokenEntity
 import dev.concert.domain.entity.UserEntity
+import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Test
 
@@ -49,12 +51,12 @@ class TokenServiceImplTest {
  
         `when`(tokenRepository.findByToken(token)).thenReturn(queueTokenEntity) 
  
-        // when 
-        val isTokenAllowed = tokenServiceImpl.isTokenExpired(token) 
- 
-        // then 
-        assertFalse(isTokenAllowed) 
-    } 
+        // when
+        val tokenResult = tokenServiceImpl.validateToken(token)
+
+        // then
+        assertThat(tokenResult).isNotEqualTo(TokenValidationResult.VALID)
+    }
 
     @Test 
     fun `토큰이 주어지면 해당 토큰에 대한 정보를 반환해야 한다`() { 
@@ -74,7 +76,7 @@ class TokenServiceImplTest {
     }
 
     @Test 
-    fun `토큰이 ACTIVE 상태인지 확인한다`() { 
+    fun `토큰이 WAITING 상태인지 확인한다`() {
         // given 
         val user = UserEntity(name = "test") 
         val token = "test" 
@@ -83,9 +85,9 @@ class TokenServiceImplTest {
         `when`(tokenRepository.findByToken(token)).thenReturn(queueTokenEntity) 
  
         // when 
-        val isAvailableToken = tokenServiceImpl.isAvailableToken(token) 
+        val tokenResult = tokenServiceImpl.validateToken(token)
  
         // then 
-        assertFalse(isAvailableToken) 
-    } 
+        assertThat(tokenResult).isEqualTo(TokenValidationResult.NOT_AVAILABLE)
+    }
 }

--- a/src/test/kotlin/dev/concert/application/token/TokenServiceImplTest.kt
+++ b/src/test/kotlin/dev/concert/application/token/TokenServiceImplTest.kt
@@ -26,66 +26,66 @@ class TokenServiceImplTest {
     @InjectMocks
     lateinit var tokenServiceImpl: TokenServiceImpl
 
-    @Test
-    fun `특정 유저에 대해서 토큰이 생성 되어야 한다`() {
-        // given
-        val userId = 1L
-        val user = UserEntity(name = "test")
-        `when`(userRepository.findById(userId)).thenReturn(user)
+    @Test 
+    fun `특정 유저에 대해서 토큰이 생성 되어야 한다`() { 
+        // given 
+        val userId = 1L 
+        val user = UserEntity(name = "test") 
+        `when`(userRepository.findById(userId)).thenReturn(user) 
+ 
+        // when 
+        val token = tokenServiceImpl.generateToken(userId) 
+ 
+        // then 
+        assertNotNull(token) 
+    } 
 
-        // when
-        val token = tokenServiceImpl.generateToken(userId)
+    @Test 
+    fun `토큰이 만료되지 않았을 때 true를 반환해야 한다`() { 
+        // given 
+        val user = UserEntity(name = "test") 
+        val token = "test" 
+        val queueTokenEntity = QueueTokenEntity(token = token, user = user) 
+ 
+        `when`(tokenRepository.findByToken(token)).thenReturn(queueTokenEntity) 
+ 
+        // when 
+        val isTokenAllowed = tokenServiceImpl.isTokenExpired(token) 
+ 
+        // then 
+        assertFalse(isTokenAllowed) 
+    } 
 
-        // then
-        assertNotNull(token)
+    @Test 
+    fun `토큰이 주어지면 해당 토큰에 대한 정보를 반환해야 한다`() { 
+        // given 
+        val user = UserEntity(name = "test") 
+        val token = "test" 
+        val queueTokenEntity = QueueTokenEntity(token = token, user = user) 
+ 
+        `when`(tokenRepository.findByToken(token)).thenReturn(queueTokenEntity) 
+ 
+        // when 
+        val tokenResponseDto = tokenServiceImpl.getToken(token) 
+ 
+        // then 
+        assertNotNull(tokenResponseDto) 
+        assertThat(tokenResponseDto.token).isEqualTo(token) 
     }
 
-    @Test
-    fun `토큰이 만료되지 않았을 때 true를 반환해야 한다`() {
-        // given
-        val user = UserEntity(name = "test")
-        val token = "test"
-        val queueTokenEntity = QueueTokenEntity(token = token, user = user)
-
-        `when`(tokenRepository.findByToken(token)).thenReturn(queueTokenEntity)
-
-        // when
-        val isTokenAllowed = tokenServiceImpl.isTokenExpired(token)
-
-        // then
-        assertFalse(isTokenAllowed)
-    }
-
-    @Test
-    fun `토큰이 주어지면 해당 토큰에 대한 정보를 반환해야 한다`() {
-        // given
-        val user = UserEntity(name = "test")
-        val token = "test"
-        val queueTokenEntity = QueueTokenEntity(token = token, user = user)
-
-        `when`(tokenRepository.findByToken(token)).thenReturn(queueTokenEntity)
-
-        // when
-        val tokenResponseDto = tokenServiceImpl.getToken(token)
-
-        // then
-        assertNotNull(tokenResponseDto)
-        assertThat(tokenResponseDto.token).isEqualTo(token)
-    }
-
-    @Test
-    fun `토큰이 ACTIVE 상태인지 확인한다`() {
-        // given
-        val user = UserEntity(name = "test")
-        val token = "test"
-        val queueTokenEntity = QueueTokenEntity(token = token, user = user)
-
-        `when`(tokenRepository.findByToken(token)).thenReturn(queueTokenEntity)
-
-        // when
-        val isAvailableToken = tokenServiceImpl.isAvailableToken(token)
-
-        // then
-        assertFalse(isAvailableToken)
-    }
+    @Test 
+    fun `토큰이 ACTIVE 상태인지 확인한다`() { 
+        // given 
+        val user = UserEntity(name = "test") 
+        val token = "test" 
+        val queueTokenEntity = QueueTokenEntity(token = token, user = user) 
+ 
+        `when`(tokenRepository.findByToken(token)).thenReturn(queueTokenEntity) 
+ 
+        // when 
+        val isAvailableToken = tokenServiceImpl.isAvailableToken(token) 
+ 
+        // then 
+        assertFalse(isAvailableToken) 
+    } 
 }


### PR DESCRIPTION
# 토큰 발급 조회 API

기존에는 Filter 로 구현을 했었는데 토큰을 검증하는 과정에서 비즈니스 Service 의 로직을 통해 검증을 해야하기 때문에
Low-Level 인 Filter 보다는 High-Level인 Interceptor 가 맞다고 판단해서 Integerceptor 에서 토큰 validation 을 하도록 변경했습니다 (main 브랜치에 통합하면서 전체 테스트 과정과 함께 기존 필터 제거 예정)

1. 토큰을 발급하고 이후 로직부터 토큰이 있어야 API 요청이 가능합니다
2. 스케줄러를 통해서 대기열 관리를 합니다