### PR TITLE
예약 / 포인트 락 구현 및 통합 테스트 작성

### DIFF
--- a/src/main/kotlin/dev/concert/infrastructure/jpa/PointJpaRepository.kt
+++ b/src/main/kotlin/dev/concert/infrastructure/jpa/PointJpaRepository.kt
@@ -2,8 +2,11 @@ package dev.concert.infrastructure.jpa
 
 import dev.concert.domain.entity.PointEntity
 import dev.concert.domain.entity.UserEntity
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 
 interface PointJpaRepository : JpaRepository<PointEntity, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     fun findByUser(user : UserEntity) : PointEntity?
 }

--- a/src/main/kotlin/dev/concert/infrastructure/jpa/SeatJpaRepository.kt
+++ b/src/main/kotlin/dev/concert/infrastructure/jpa/SeatJpaRepository.kt
@@ -10,9 +10,9 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
 interface SeatJpaRepository : JpaRepository<SeatEntity, Long> {
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT s FROM SeatEntity s WHERE s.id = :seatId")
-    fun getSeatWithLock(@Param("seatId") seatId: Long): SeatEntity?
+    @Lock(LockModeType.PESSIMISTIC_WRITE) 
+    @Query("SELECT s FROM SeatEntity s WHERE s.id = :seatId") 
+    fun getSeatWithLock(@Param("seatId") seatId: Long): SeatEntity? 
 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE SeatEntity s SET s.seatStatus = 'AVAILABLE' WHERE s.id IN :seatIds")

--- a/src/test/kotlin/dev/concert/application/concert/facade/ConcertFacadeTest.kt
+++ b/src/test/kotlin/dev/concert/application/concert/facade/ConcertFacadeTest.kt
@@ -181,85 +181,85 @@ class ConcertFacadeTest {
         assertThat(seat.seatStatus).isEqualTo(SeatStatus.TEMPORARILY_ASSIGNED)
     }
 
-    @Test
-    fun `콘서트 좌석 예약 10명 동시성 테스트`() {
-        // given
-        val seatId = 1L
-        val userIds = (1L..10L).toList() // 10명의 사용자 ID 리스트
-
-        // 10개의 예약 요청 생성
-        val requests = userIds.map { userId ->
-            ConcertReservationDto(
-                userId = userId,
-                seatId = seatId
-            )
-        }
-
-        // when
-        val startTime = System.currentTimeMillis() // 시간 측정 시작
-        requests.map { request ->
-            CompletableFuture.runAsync {
-                try {
-                    concertFacade.reserveSeat(request)
-                } catch (e: Exception) {
-                    println("예약 실패 : ${request.userId}: ${e.message}")
-                }
-            }
-        }.forEach { it.join() }
-
-        val endTime = System.currentTimeMillis() // 시간 측정 종료
-
-        // 소요 시간 계산
-        val elapsedTime = endTime - startTime
-        println("소요시간: $elapsedTime ms")
-
-        // then
-        val seat = seatRepository.findById(1L)?: throw Exception("seat not found")
-        val reservations = reservationRepository.findAll()
-        assertThat(seat).isNotNull
-        assertThat(seat.seatStatus).isEqualTo(SeatStatus.TEMPORARILY_ASSIGNED)
-        assertThat(reservations).hasSize(1)
-    }
-
-    @Test
-    fun `콘서트 좌석 예약 100명 동시성 테스트`() {
-        // given
-        val seatId = 1L
-        val userIds = (1L..100L).toList() // 10명의 사용자 ID 리스트
-
-        // 10개의 예약 요청 생성
-        val requests = userIds.map { userId ->
-            ConcertReservationDto(
-                userId = userId,
-                seatId = seatId
-            )
-        }
-
-        // when
-        val startTime = System.currentTimeMillis() // 시간 측정 시작
-        requests.map { request ->
-            CompletableFuture.runAsync {
-                try {
-                    concertFacade.reserveSeat(request)
-                } catch (e: Exception) {
-                    println("예약 실패 : ${request.userId}: ${e.message}")
-                }
-            }
-        }.forEach { it.join() }
-
-        val endTime = System.currentTimeMillis() // 시간 측정 종료
-
-        // 소요 시간 계산
-        val elapsedTime = endTime - startTime
-        println("소요시간: $elapsedTime ms")
-
-        // then
-        val seat = seatRepository.findById(1L)?: throw Exception("seat not found")
-        val reservations = reservationRepository.findAll()
-        assertThat(seat).isNotNull
-        assertThat(seat.seatStatus).isEqualTo(SeatStatus.TEMPORARILY_ASSIGNED)
-        assertThat(reservations).hasSize(1)
-    }
+    @Test 
+    fun `콘서트 좌석 예약 10명 동시성 테스트`() { 
+        // given 
+        val seatId = 1L 
+        val userIds = (1L..10L).toList() // 10명의 사용자 ID 리스트 
+ 
+        // 10개의 예약 요청 생성 
+        val requests = userIds.map { userId -> 
+            ConcertReservationDto( 
+                userId = userId, 
+                seatId = seatId 
+            ) 
+        } 
+ 
+        // when 
+        val startTime = System.currentTimeMillis() // 시간 측정 시작 
+        requests.map { request -> 
+            CompletableFuture.runAsync { 
+                try { 
+                    concertFacade.reserveSeat(request) 
+                } catch (e: Exception) { 
+                    println("예약 실패 : ${request.userId}: ${e.message}") 
+                } 
+            } 
+        }.forEach { it.join() } 
+ 
+        val endTime = System.currentTimeMillis() // 시간 측정 종료 
+ 
+        // 소요 시간 계산 
+        val elapsedTime = endTime - startTime  
+        println("소요시간: $elapsedTime ms") 
+ 
+        // then 
+        val seat = seatRepository.findById(1L)?: throw Exception("seat not found") 
+        val reservations = reservationRepository.findAll() 
+        assertThat(seat).isNotNull 
+        assertThat(seat.seatStatus).isEqualTo(SeatStatus.TEMPORARILY_ASSIGNED) 
+        assertThat(reservations).hasSize(1) 
+    } 
+ 
+    @Test 
+    fun `콘서트 좌석 예약 100명 동시성 테스트`() { 
+        // given 
+        val seatId = 1L 
+        val userIds = (1L..100L).toList() // 10명의 사용자 ID 리스트 
+ 
+        // 10개의 예약 요청 생성 
+        val requests = userIds.map { userId -> 
+            ConcertReservationDto( 
+                userId = userId, 
+                seatId = seatId 
+            ) 
+        } 
+ 
+        // when 
+        val startTime = System.currentTimeMillis() // 시간 측정 시작 
+        requests.map { request -> 
+            CompletableFuture.runAsync { 
+                try { 
+                    concertFacade.reserveSeat(request) 
+                } catch (e: Exception) { 
+                    println("예약 실패 : ${request.userId}: ${e.message}") 
+                } 
+            } 
+        }.forEach { it.join() } 
+ 
+        val endTime = System.currentTimeMillis() // 시간 측정 종료 
+ 
+        // 소요 시간 계산 
+        val elapsedTime = endTime - startTime 
+        println("소요시간: $elapsedTime ms") 
+ 
+        // then 
+        val seat = seatRepository.findById(1L)?: throw Exception("seat not found") 
+        val reservations = reservationRepository.findAll() 
+        assertThat(seat).isNotNull 
+        assertThat(seat.seatStatus).isEqualTo(SeatStatus.TEMPORARILY_ASSIGNED) 
+        assertThat(reservations).hasSize(1) 
+    } 
 
     @Test
     fun `콘서트 좌석 예약 스케줄러가 돌아서 바로 예약한 직후는 상태를 변경하지 않는다`() {

--- a/src/test/kotlin/dev/concert/domain/service/point/PointIntegrationTest.kt
+++ b/src/test/kotlin/dev/concert/domain/service/point/PointIntegrationTest.kt
@@ -1,0 +1,113 @@
+package dev.concert.domain.service.point
+
+import dev.concert.domain.entity.ConcertEntity
+import dev.concert.domain.entity.ConcertOptionEntity
+import dev.concert.domain.entity.ReservationEntity
+import dev.concert.domain.entity.SeatEntity
+import dev.concert.domain.entity.UserEntity
+import dev.concert.domain.repository.ConcertRepository
+import dev.concert.domain.repository.ReservationRepository
+import dev.concert.domain.repository.SeatRepository
+import dev.concert.domain.service.payment.PaymentService
+import dev.concert.domain.service.user.UserService
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.time.LocalDateTime
+import java.util.concurrent.CompletableFuture
+
+@SpringBootTest
+class PointIntegrationTest {
+
+    @Autowired
+    private lateinit var pointService: PointService
+
+    @Autowired
+    private lateinit var paymentService: PaymentService
+
+    @Autowired
+    private lateinit var reservationRepository: ReservationRepository
+
+    @Autowired
+    private lateinit var seatRepository: SeatRepository
+
+    @Autowired
+    private lateinit var concertRepository: ConcertRepository
+
+    @Autowired
+    private lateinit var userService : UserService
+
+    @BeforeEach
+    fun setUp() {
+        // given
+        val user = userService.saveUser(UserEntity("변주환"))
+        val concert = concertRepository.saveConcert(
+            ConcertEntity(
+                concertName = "콘서트1",
+                singer = "가수1",
+                startDate = "20241201",
+                endDate = "20241201",
+                reserveStartDate = "20241201",
+                reserveEndDate = "20241201",
+            )
+        )
+
+        val concertOption = concertRepository.saveConcertOption(
+            ConcertOptionEntity(
+                concert = concert,
+                concertDate = "20241201",
+                concertTime = "12:00",
+                concertVenue = "올림픽체조경기장",
+                availableSeats = 100,
+            )
+        )
+
+        val seat = seatRepository.save(
+            SeatEntity(
+                concertOption = concertOption,
+                price = 1000,
+                seatNo = 1,
+            )
+        )
+
+        val expiresAt = LocalDateTime.now().plusMinutes(5)
+
+        val reservation = ReservationEntity(
+            user = user,
+            seat = seat,
+            expiresAt = expiresAt,
+        )
+
+        // 예약 정보를 저장한다
+        reservationRepository.saveReservation(reservation)
+
+        pointService.chargePoints(user,1000)
+    }
+
+    @Test
+    fun `유저 포인트 저장 차감 동시성 테스트`() {
+        // given
+        val user = userService.getUser(1L)
+        val reservation = reservationRepository.findById(1L) ?: throw RuntimeException("예약 없음")
+
+        // when
+        CompletableFuture.allOf(
+            CompletableFuture.runAsync {
+                paymentService.processReservationPayment(reservation.id)
+            },
+            CompletableFuture.runAsync {
+                pointService.chargePoints(user, 300)
+            },
+            CompletableFuture.runAsync {
+                pointService.chargePoints(user, 200)
+            }
+        ).join()
+
+        // then
+        val currentPoint = pointService.getCurrentPoint(user)
+        assertEquals(1000 - 1000 + 300 + 200, currentPoint.point)
+    }
+}


### PR DESCRIPTION
# 예약 / 포인트 락 구현 및 통합 테스트 작성

- 예약 동시성 이슈 : 비관적 락의 `PESSIMISTIC_WRITE ` 으로 구현 했습니다. 이번 보고서를 작성하면서 100명까지의 동시성 테스트 결과 가장 성능적인 면으로 빠른 속도를 보여줬기 때문에 선택했습니다.
- 포인트 동시성 이슈 : 개인적인 생각으로는 포인트 충전과 차감이 동시에 일어날 일이 많지 않다고 생각해서 낙관적 락으로 구현할까 했지만 금액적인 부분을 다루는 민감한 부분이다보니 확실하게 DB 락 까지 걸어서 안전하게 처리하자 라고 생각해서 이쪽도 비관적 락의 `PESSIMISTIC_WRITE` 으로 구현 했습니다.