### PR TITLE
[대기열 구현] DB -> Redis 변경

### DIFF
--- a/src/main/kotlin/dev/concert/domain/repository/QueueTokenRepository.kt
+++ b/src/main/kotlin/dev/concert/domain/repository/QueueTokenRepository.kt
@@ -1,15 +1,15 @@
 package dev.concert.domain.repository
-
-interface QueueTokenRepository {
-    fun findTokenByKey(key: String) : String?
-    fun addWaitingQueue(userJson: String, currentTime: Double)
-    fun createToken(userKey: String, token: String)
-    fun getTokenExpireTime(userKey: String) : Long?
-    fun deleteTokenActiveQueue(token: String)
-    fun deleteToken(userKey: String)
-    fun findTopWaitingTokens(start: Long, end: Long): Set<String>?
-    fun addActiveQueue(token: String)
-    fun removeWaitingQueueToken(userJson: String)
-    fun isTokenInActiveQueue(userJson : String) : Boolean
-    fun getRankInWaitingQueue(userJson: String) : Long?
-}
+ 
+interface QueueTokenRepository { 
+    fun findTokenByKey(key: String) : String? 
+    fun addWaitingQueue(userJson: String, currentTime: Double) 
+    fun createToken(userKey: String, token: String) 
+    fun getTokenExpireTime(userKey: String) : Long? 
+    fun deleteTokenActiveQueue(token: String) 
+    fun deleteToken(userKey: String) 
+    fun findTopWaitingTokens(start: Long, end: Long): Set<String>? 
+    fun addActiveQueue(token: String) 
+    fun removeWaitingQueueToken(userJson: String) 
+    fun isTokenInActiveQueue(userJson : String) : Boolean 
+    fun getRankInWaitingQueue(userJson: String) : Long? 
+} 

--- a/src/main/kotlin/dev/concert/domain/service/token/TokenRedisServiceImpl.kt
+++ b/src/main/kotlin/dev/concert/domain/service/token/TokenRedisServiceImpl.kt
@@ -17,117 +17,117 @@ import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Service
 import java.util.*
+ 
+@Service 
+@Primary 
+class TokenRedisServiceImpl( 
+    private val queueTokenRepository: QueueTokenRepository, 
+    private val lockKeyGenerator: LockKeyGenerator, 
+) : TokenService { 
+ 
+    private val log : Logger = LoggerFactory.getLogger(TokenRedisServiceImpl::class.java) 
+ 
+    private val objectMapper : ObjectMapper = jacksonObjectMapper() 
+ 
+    override fun generateToken(user: UserEntity): String { 
+        val userKey = generateUserKey(user.id) 
+        val existingToken = queueTokenRepository.findTokenByKey(userKey) 
+ 
+        return existingToken ?: run { 
+            val token = encodeUserId() 
+            val userJson = objectMapper.writeValueAsString(user) 
+            val currentTime = System.currentTimeMillis().toDouble() 
+ 
+            queueTokenRepository.addWaitingQueue(userJson, currentTime) 
+            queueTokenRepository.createToken(userKey, token) 
+            token 
+        } 
+    } 
+ 
+    override fun getToken(user: UserEntity): TokenResponseDto { 
+        val userKey = generateUserKey(user.id) 
+        val userJson = objectMapper.writeValueAsString(user) 
+        val remainingTime = queueTokenRepository.getTokenExpireTime(userKey) ?: 0 
+        val token = queueTokenRepository.findTokenByKey(userKey) ?: throw ConcertException(ErrorCode.TOKEN_NOT_FOUND) 
+ 
+        // 큐에서 상태 확인 
+        val status = checkQueueTokenStatus(userJson, token) 
+ 
+        // 순서 조회 
+        val queueOrder = calcQueueOrder(status, userJson) 
+ 
+        return TokenResponseDto( 
+            token = token, 
+            status = status, 
+            queueOrder = queueOrder, 
+            remainingTime = remainingTime 
+        ) 
+    } 
 
-@Service
-@Primary
-class TokenRedisServiceImpl(
-    private val queueTokenRepository: QueueTokenRepository,
-    private val lockKeyGenerator: LockKeyGenerator,
-) : TokenService {
 
-    private val log : Logger = LoggerFactory.getLogger(TokenRedisServiceImpl::class.java)
-
-    private val objectMapper : ObjectMapper = jacksonObjectMapper()
-
-    override fun generateToken(user: UserEntity): String {
-        val userKey = generateUserKey(user.id)
-        val existingToken = queueTokenRepository.findTokenByKey(userKey)
-
-        return existingToken ?: run {
-            val token = encodeUserId()
-            val userJson = objectMapper.writeValueAsString(user)
-            val currentTime = System.currentTimeMillis().toDouble()
-
-            queueTokenRepository.addWaitingQueue(userJson, currentTime)
-            queueTokenRepository.createToken(userKey, token)
-            token
-        }
-    }
-
-    override fun getToken(user: UserEntity): TokenResponseDto {
-        val userKey = generateUserKey(user.id)
-        val userJson = objectMapper.writeValueAsString(user)
-        val remainingTime = queueTokenRepository.getTokenExpireTime(userKey) ?: 0
-        val token = queueTokenRepository.findTokenByKey(userKey) ?: throw ConcertException(ErrorCode.TOKEN_NOT_FOUND)
-
-        // 큐에서 상태 확인
-        val status = checkQueueTokenStatus(userJson, token)
-
-        // 순서 조회
-        val queueOrder = calcQueueOrder(status, userJson)
-
-        return TokenResponseDto(
-            token = token,
-            status = status,
-            queueOrder = queueOrder,
-            remainingTime = remainingTime
-        )
-    }
-
-
-    override fun deleteToken(user: UserEntity) {
-        val token = queueTokenRepository.findTokenByKey(generateUserKey(user.id))
-            ?: throw ConcertException(ErrorCode.TOKEN_NOT_FOUND)
-        queueTokenRepository.deleteTokenActiveQueue(token)
-        queueTokenRepository.deleteToken(generateUserKey(user.id))
-        log.info("토큰 삭제 완료")
+    override fun deleteToken(user: UserEntity) { 
+        val token = queueTokenRepository.findTokenByKey(generateUserKey(user.id)) 
+            ?: throw ConcertException(ErrorCode.TOKEN_NOT_FOUND) 
+        queueTokenRepository.deleteTokenActiveQueue(token) 
+        queueTokenRepository.deleteToken(generateUserKey(user.id)) 
+        log.info("토큰 삭제 완료") 
     }
 
     /**
      * user - token 에서 token 을 가져와서
      * wait_queue 에서 active_queue 로 이동
-     * 1분마다 10 명씩 이동
+     * 10초마다 1000 개씩 이동
      */
-    override fun manageTokenStatus() {
-        val tokenList = queueTokenRepository.findTopWaitingTokens(0, 1999)
-        tokenList?.forEach { userJson ->
-            runCatching {
-                val user: UserEntity = objectMapper.readValue(userJson)
-                val userKey = generateUserKey(user.id)
-                val token = queueTokenRepository.findTokenByKey(userKey) ?: throw ConcertException(ErrorCode.TOKEN_NOT_FOUND)
-                queueTokenRepository.addActiveQueue(token)
-                queueTokenRepository.removeWaitingQueueToken(userJson)
-            }.onFailure { e->
-                log.error("WaitingQueue -> ActiveQueue Error : $userJson", e)
-            }
-        }
-    }
-
+    override fun manageTokenStatus() { 
+        val tokenList = queueTokenRepository.findTopWaitingTokens(0, 1999) 
+        tokenList?.forEach { userJson -> 
+            runCatching { 
+                val user: UserEntity = objectMapper.readValue(userJson) 
+                val userKey = generateUserKey(user.id) 
+                val token = queueTokenRepository.findTokenByKey(userKey) ?: throw ConcertException(ErrorCode.TOKEN_NOT_FOUND) 
+                queueTokenRepository.addActiveQueue(token) 
+                queueTokenRepository.removeWaitingQueueToken(userJson) 
+            }.onFailure { e-> 
+                log.error("WaitingQueue -> ActiveQueue Error : $userJson", e) 
+            } 
+        } 
+    } 
+  
     override fun manageExpiredTokens() {
         TODO("Not yet implemented")
     }
 
-    override fun validateToken(token: String): TokenValidationResult {
-        return  when {
-            !queueTokenRepository.isTokenInActiveQueue(token) -> TokenValidationResult.NOT_AVAILABLE
-            else -> TokenValidationResult.VALID
-        }
-    }
+    override fun validateToken(token: String): TokenValidationResult { 
+        return  when { 
+            !queueTokenRepository.isTokenInActiveQueue(token) -> TokenValidationResult.NOT_AVAILABLE 
+            else -> TokenValidationResult.VALID 
+        } 
+    } 
 
-    private fun encodeUserId() : String {
-        val uuid = UUID.randomUUID().toString()
-        val timeStamp = System.currentTimeMillis().toString()
-        return Base64Util.encode((uuid + timeStamp).toByteArray())
-    }
+    private fun encodeUserId() : String { 
+        val uuid = UUID.randomUUID().toString() 
+        val timeStamp = System.currentTimeMillis().toString() 
+        return Base64Util.encode((uuid + timeStamp).toByteArray()) 
+    } 
 
-    private fun checkQueueTokenStatus(userJson: String, token: String): QueueTokenStatus {
-        return when {
-            queueTokenRepository.isTokenInActiveQueue(token) -> QueueTokenStatus.ACTIVE
-            queueTokenRepository.getRankInWaitingQueue(userJson) != null -> QueueTokenStatus.WAITING
-            else -> throw ConcertException(ErrorCode.TOKEN_NOT_FOUND)
-        }
-    }
-    private fun calcQueueOrder(status: QueueTokenStatus, userJson: String) =
-        if (status == QueueTokenStatus.WAITING) {
-            queueTokenRepository.getRankInWaitingQueue(userJson)?.toInt() ?: -1
-        } else {
-            0
-        }
-
+    private fun checkQueueTokenStatus(userJson: String, token: String): QueueTokenStatus { 
+        return when { 
+            queueTokenRepository.isTokenInActiveQueue(token) -> QueueTokenStatus.ACTIVE 
+            queueTokenRepository.getRankInWaitingQueue(userJson) != null -> QueueTokenStatus.WAITING 
+            else -> throw ConcertException(ErrorCode.TOKEN_NOT_FOUND) 
+        } 
+    } 
+    private fun calcQueueOrder(status: QueueTokenStatus, userJson: String) = 
+        if (status == QueueTokenStatus.WAITING) { 
+            queueTokenRepository.getRankInWaitingQueue(userJson)?.toInt() ?: -1 
+        } else { 
+            0 
+        } 
+ 
     /**
      * 사용자 ID로 유저 키 생성
      */
-    private fun generateUserKey(userId: Long): String {
-        return lockKeyGenerator.generateLockKeyWithPrefix(prefix = "user", param = userId)
-    }
-}
+    private fun generateUserKey(userId: Long): String { 
+        return lockKeyGenerator.generateLockKeyWithPrefix(prefix = "user", param = userId) 
+    } 
+} 

--- a/src/main/kotlin/dev/concert/domain/util/lock/LockKeyGenerator.kt
+++ b/src/main/kotlin/dev/concert/domain/util/lock/LockKeyGenerator.kt
@@ -1,6 +1,6 @@
 package dev.concert.domain.util.lock
-
-interface LockKeyGenerator {
-
-    fun generateLockKeyWithPrefix(prefix : String, param : Any): String
-}
+ 
+interface LockKeyGenerator { 
+ 
+    fun generateLockKeyWithPrefix(prefix : String, param : Any): String 
+} 

--- a/src/main/kotlin/dev/concert/infrastructure/redis/RedisLockKeyManager.kt
+++ b/src/main/kotlin/dev/concert/infrastructure/redis/RedisLockKeyManager.kt
@@ -2,10 +2,10 @@ package dev.concert.infrastructure.redis
 
 import dev.concert.domain.util.lock.LockKeyGenerator
 import org.springframework.stereotype.Component
-
-@Component
-class RedisLockKeyManager : LockKeyGenerator {
-    override fun generateLockKeyWithPrefix(prefix: String, param: Any): String {
-        return "$prefix:$param"
-    }
-}
+ 
+@Component 
+class RedisLockKeyManager : LockKeyGenerator { 
+    override fun generateLockKeyWithPrefix(prefix: String, param: Any): String { 
+        return "$prefix:$param" 
+    } 
+} 

--- a/src/main/kotlin/dev/concert/infrastructure/redis/TokenRedisRepositoryImpl.kt
+++ b/src/main/kotlin/dev/concert/infrastructure/redis/TokenRedisRepositoryImpl.kt
@@ -7,54 +7,54 @@ import dev.concert.domain.util.consts.WAITING_QUEUE
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Repository
 import java.util.concurrent.TimeUnit
+ 
+@Repository 
+class TokenRedisRepositoryImpl( 
+    private val redisTemplate: RedisTemplate<String, String>, 
+) : QueueTokenRepository { 
+ 
+    override fun findTokenByKey(key: String): String? { 
+        return redisTemplate.opsForValue().get(key) 
+    } 
+ 
+    override fun addWaitingQueue(userJson: String, currentTime: Double) { 
+        redisTemplate.opsForZSet().add(WAITING_QUEUE, userJson, currentTime) 
+    } 
+ 
+    override fun createToken(userKey: String, token: String) { 
+        redisTemplate.opsForValue().set(userKey, token, 1, TimeUnit.HOURS) 
+    } 
 
-@Repository
-class TokenRedisRepositoryImpl(
-    private val redisTemplate: RedisTemplate<String, String>,
-) : QueueTokenRepository {
+    override fun getTokenExpireTime(userKey: String): Long? { 
+        return redisTemplate.getExpire(userKey, TimeUnit.SECONDS) 
+    } 
 
-    override fun findTokenByKey(key: String): String? {
-        return redisTemplate.opsForValue().get(key)
-    }
+    override fun deleteTokenActiveQueue(token: String) { 
+        redisTemplate.opsForSet().remove(ACTIVE_QUEUE, token) 
+    } 
 
-    override fun addWaitingQueue(userJson: String, currentTime: Double) {
-        redisTemplate.opsForZSet().add(WAITING_QUEUE, userJson, currentTime)
-    }
+    override fun deleteToken(userKey: String) { 
+        redisTemplate.delete(userKey) 
+    } 
 
-    override fun createToken(userKey: String, token: String) {
-        redisTemplate.opsForValue().set(userKey, token, 1, TimeUnit.HOURS)
-    }
+    override fun findTopWaitingTokens(start: Long, end: Long): Set<String>? { 
+        return redisTemplate.opsForZSet().range(WAITING_QUEUE, start, end) 
+    } 
 
-    override fun getTokenExpireTime(userKey: String): Long? {
-        return redisTemplate.getExpire(userKey, TimeUnit.SECONDS)
-    }
+    override fun addActiveQueue(token: String) { 
+        redisTemplate.opsForSet().add(ACTIVE_QUEUE, token) 
+    } 
 
-    override fun deleteTokenActiveQueue(token: String) {
-        redisTemplate.opsForSet().remove(ACTIVE_QUEUE, token)
-    }
+    override fun removeWaitingQueueToken(userJson: String) { 
+        redisTemplate.opsForZSet().remove(WAITING_QUEUE, userJson) 
+    } 
 
-    override fun deleteToken(userKey: String) {
-        redisTemplate.delete(userKey)
-    }
+    override fun isTokenInActiveQueue(userJson: String): Boolean { 
+        return redisTemplate.opsForSet().isMember(ACTIVE_QUEUE, userJson) ?: false 
+    } 
 
-    override fun findTopWaitingTokens(start: Long, end: Long): Set<String>? {
-        return redisTemplate.opsForZSet().range(WAITING_QUEUE, start, end)
-    }
-
-    override fun addActiveQueue(token: String) {
-        redisTemplate.opsForSet().add(ACTIVE_QUEUE, token)
-    }
-
-    override fun removeWaitingQueueToken(userJson: String) {
-        redisTemplate.opsForZSet().remove(WAITING_QUEUE, userJson)
-    }
-
-    override fun isTokenInActiveQueue(userJson: String): Boolean {
-        return redisTemplate.opsForSet().isMember(ACTIVE_QUEUE, userJson) ?: false
-    }
-
-    override fun getRankInWaitingQueue(userJson: String): Long? {
-        return redisTemplate.opsForZSet().rank(WAITING_QUEUE, userJson)
-    }
+    override fun getRankInWaitingQueue(userJson: String): Long? { 
+        return redisTemplate.opsForZSet().rank(WAITING_QUEUE, userJson) 
+    } 
 
 }

--- a/src/main/kotlin/dev/concert/interfaces/scheduler/TokenQueueScheduler.kt
+++ b/src/main/kotlin/dev/concert/interfaces/scheduler/TokenQueueScheduler.kt
@@ -12,7 +12,7 @@ class TokenQueueScheduler (
     /**
      * 토큰을 Waiting Queue 에서 Active Queue 로 이동시키는 스케줄러
      */
-    @Scheduled(fixedRate = 60000) // 1분 마다 실행
+    @Scheduled(fixedRate = 10000) // 10초 마다 실행
     fun tokenScheduler() {
         tokenFacade.manageTokenStatus()
     }


### PR DESCRIPTION
# DB 로 구현된 대기열을 Redis 로 변경하기

Redis 의 Sorted Set 을 사용해서 구현했고, TokenService 의 구현체만 갈아 끼우는 형식으로 개발했습니다.
분산락, 캐시 전부 Key 를 기반으로 저장하고 동작하므로 key 에 대한 응집도를 높이기위해  LockKeyGenerator 를 생성했습니다

대기열 구현에 대한 부가 설명은 캐싱 정리 문서 와 함께 추가 정리 했습니다!