### PR TITLE
[외부 API 구현] 이벤트를 통한 외부 API 연동 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,9 @@ dependencies {
 
 	// Redis
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
+	// Slack
+	implementation("com.slack.api:slack-api-client:1.20.2")
 }
 
 kotlin {

--- a/src/main/kotlin/dev/concert/ConsertApplication.kt
+++ b/src/main/kotlin/dev/concert/ConsertApplication.kt
@@ -3,8 +3,10 @@ package dev.concert
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.cache.annotation.EnableCaching
+import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.annotation.EnableScheduling
 
+@EnableAsync
 @EnableCaching
 @EnableScheduling
 @SpringBootApplication

--- a/src/main/kotlin/dev/concert/application/concert/ConcertFacade.kt
+++ b/src/main/kotlin/dev/concert/application/concert/ConcertFacade.kt
@@ -11,6 +11,7 @@ import dev.concert.domain.service.reservation.event.ReservationSuccessEvent
 import dev.concert.domain.service.reservation.publisher.ReservationEventPublisher
 import dev.concert.domain.service.user.UserService
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 @Component
 class ConcertFacade (
@@ -55,6 +56,7 @@ class ConcertFacade (
         }
     }
 
+    @Transactional
     fun reserveSeat(request: ConcertReservationDto): ConcertReservationResponseDto {
         // 유저 정보 조회
         val user = userService.getUser(request.userId)

--- a/src/main/kotlin/dev/concert/application/concert/ConcertFacade.kt
+++ b/src/main/kotlin/dev/concert/application/concert/ConcertFacade.kt
@@ -7,6 +7,8 @@ import dev.concert.application.concert.dto.ConcertSeatsDto
 import dev.concert.application.concert.dto.ConcertsDto
 import dev.concert.domain.service.concert.ConcertService
 import dev.concert.domain.service.reservation.ReservationService
+import dev.concert.domain.service.reservation.event.ReservationSuccessEvent
+import dev.concert.domain.service.reservation.publisher.ReservationEventPublisher
 import dev.concert.domain.service.user.UserService
 import org.springframework.stereotype.Component
 
@@ -15,6 +17,7 @@ class ConcertFacade (
     private val userService: UserService,
     private val concertService: ConcertService,
     private val reservationService: ReservationService,
+    private val eventPublisher: ReservationEventPublisher,
 ){
     fun getConcerts(): List<ConcertsDto> {
         return concertService.getConcerts().map { ConcertsDto(
@@ -58,6 +61,9 @@ class ConcertFacade (
 
         //예약가능인지 확인하고 좌석 임시배정해 잠근다.
         val reservation = reservationService.createSeatReservation(user, request.seatId)
+
+        // 예약 성공 이벤트 발행
+        eventPublisher.publish(ReservationSuccessEvent(reservation.id))
 
         return ConcertReservationResponseDto(
             status = reservation.status,

--- a/src/main/kotlin/dev/concert/application/data/DataPlatformFacade.kt
+++ b/src/main/kotlin/dev/concert/application/data/DataPlatformFacade.kt
@@ -3,6 +3,7 @@ package dev.concert.application.data
 import dev.concert.domain.service.data.DataPlatformService
 import dev.concert.domain.service.reservation.ReservationService
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class DataPlatformFacade (
@@ -10,6 +11,7 @@ class DataPlatformFacade (
     private val reservationService : ReservationService,
 ) {
 
+    @Transactional
     fun sendReservationData(reservationId : Long) {
         val reservation = reservationService.getReservation(reservationId)
         dataPlatformService.sendReservationData(reservation)

--- a/src/main/kotlin/dev/concert/application/data/DataPlatformFacade.kt
+++ b/src/main/kotlin/dev/concert/application/data/DataPlatformFacade.kt
@@ -1,0 +1,17 @@
+package dev.concert.application.data
+
+import dev.concert.domain.service.data.DataPlatformService
+import dev.concert.domain.service.reservation.ReservationService
+import org.springframework.stereotype.Service
+
+@Service
+class DataPlatformFacade (
+    private val dataPlatformService : DataPlatformService,
+    private val reservationService : ReservationService,
+) {
+
+    fun sendReservationData(reservationId : Long) {
+        val reservation = reservationService.getReservation(reservationId)
+        dataPlatformService.sendReservationData(reservation)
+    }
+}

--- a/src/main/kotlin/dev/concert/config/InterceptorConfig.kt
+++ b/src/main/kotlin/dev/concert/config/InterceptorConfig.kt
@@ -8,7 +8,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
 class InterceptorConfig (
-    private val tokenValidateInterceptor: TokenValidateInterceptor,
+//    private val tokenValidateInterceptor: TokenValidateInterceptor,
     private val activeTokenValidateInterceptor: ActiveTokenValidateInterceptor,
 ) : WebMvcConfigurer {
 

--- a/src/main/kotlin/dev/concert/domain/event/ReservationSuccessEvent.kt
+++ b/src/main/kotlin/dev/concert/domain/event/ReservationSuccessEvent.kt
@@ -1,0 +1,3 @@
+package dev.concert.domain.event
+
+class ReservationSuccessEvent (val reservationKey : Long)

--- a/src/main/kotlin/dev/concert/domain/event/publisher/ReservationEventPublisher.kt
+++ b/src/main/kotlin/dev/concert/domain/event/publisher/ReservationEventPublisher.kt
@@ -1,0 +1,7 @@
+package dev.concert.domain.event.publisher
+
+import dev.concert.domain.event.ReservationSuccessEvent
+
+interface ReservationEventPublisher {
+    fun publish(event : ReservationSuccessEvent)
+}

--- a/src/main/kotlin/dev/concert/domain/service/data/DataPlatformService.kt
+++ b/src/main/kotlin/dev/concert/domain/service/data/DataPlatformService.kt
@@ -1,0 +1,7 @@
+package dev.concert.domain.service.data
+
+import dev.concert.domain.entity.ReservationEntity
+
+interface DataPlatformService {
+    fun sendReservationData(reservation : ReservationEntity)
+}

--- a/src/main/kotlin/dev/concert/domain/service/data/DataPlatformServiceImpl.kt
+++ b/src/main/kotlin/dev/concert/domain/service/data/DataPlatformServiceImpl.kt
@@ -1,0 +1,19 @@
+package dev.concert.domain.service.data
+
+import dev.concert.domain.entity.ReservationEntity
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class DataPlatformServiceImpl (
+
+) : DataPlatformService {
+
+    private val log : Logger = LoggerFactory.getLogger(DataPlatformServiceImpl::class.java)
+
+    override fun sendReservationData(reservation: ReservationEntity) {
+        log.info("외부 API 통신 성공")
+        // TODO 슬랙, 텔레그램 알림으로 변경해보기
+    }
+}

--- a/src/main/kotlin/dev/concert/domain/service/data/DataPlatformServiceImpl.kt
+++ b/src/main/kotlin/dev/concert/domain/service/data/DataPlatformServiceImpl.kt
@@ -14,7 +14,7 @@ class DataPlatformServiceImpl (
     private val log : Logger = LoggerFactory.getLogger(DataPlatformServiceImpl::class.java)
 
     override fun sendReservationData(reservation: ReservationEntity) {
-        messageManager.sendMessage()
+        messageManager.sendMessage("예약 데이터 전송 reservationId : ${reservation.id}")
         log.info("외부 API 통신 성공")
     }
 }

--- a/src/main/kotlin/dev/concert/domain/service/data/DataPlatformServiceImpl.kt
+++ b/src/main/kotlin/dev/concert/domain/service/data/DataPlatformServiceImpl.kt
@@ -1,19 +1,20 @@
 package dev.concert.domain.service.data
 
 import dev.concert.domain.entity.ReservationEntity
+import dev.concert.domain.service.data.message.MessageManager
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
 class DataPlatformServiceImpl (
-
+    private val messageManager: MessageManager
 ) : DataPlatformService {
 
     private val log : Logger = LoggerFactory.getLogger(DataPlatformServiceImpl::class.java)
 
     override fun sendReservationData(reservation: ReservationEntity) {
+        messageManager.sendMessage()
         log.info("외부 API 통신 성공")
-        // TODO 슬랙, 텔레그램 알림으로 변경해보기
     }
 }

--- a/src/main/kotlin/dev/concert/domain/service/data/message/MessageManager.kt
+++ b/src/main/kotlin/dev/concert/domain/service/data/message/MessageManager.kt
@@ -1,5 +1,5 @@
 package dev.concert.domain.service.data.message
 
 interface MessageManager {
-    fun sendMessage()
+    fun sendMessage(message : String)
 }

--- a/src/main/kotlin/dev/concert/domain/service/data/message/MessageManager.kt
+++ b/src/main/kotlin/dev/concert/domain/service/data/message/MessageManager.kt
@@ -1,0 +1,5 @@
+package dev.concert.domain.service.data.message
+
+interface MessageManager {
+    fun sendMessage()
+}

--- a/src/main/kotlin/dev/concert/domain/service/reservation/ReservationService.kt
+++ b/src/main/kotlin/dev/concert/domain/service/reservation/ReservationService.kt
@@ -6,4 +6,5 @@ import dev.concert.domain.entity.UserEntity
 interface ReservationService {
     fun manageReservationStatus()
     fun createSeatReservation(user: UserEntity, seatId: Long): ReservationEntity
+    fun getReservation(reservationId: Long): ReservationEntity
 }

--- a/src/main/kotlin/dev/concert/domain/service/reservation/ReservationServiceImpl.kt
+++ b/src/main/kotlin/dev/concert/domain/service/reservation/ReservationServiceImpl.kt
@@ -38,6 +38,11 @@ class ReservationServiceImpl (
         return saveReservation(user, seat)
     }
 
+    @Transactional(readOnly = true)
+    override fun getReservation(reservationId: Long): ReservationEntity {
+        return reservationRepository.findById(reservationId) ?: throw ConcertException(ErrorCode.RESERVATION_NOT_FOUND)
+    }
+
     private fun saveReservation(user: UserEntity, seat: SeatEntity) : ReservationEntity {
         val expiresAt = LocalDateTime.now().plusMinutes(5)
 

--- a/src/main/kotlin/dev/concert/domain/service/reservation/event/ReservationSuccessEvent.kt
+++ b/src/main/kotlin/dev/concert/domain/service/reservation/event/ReservationSuccessEvent.kt
@@ -1,0 +1,3 @@
+package dev.concert.domain.service.reservation.event
+
+data class ReservationSuccessEvent (val reservationId : Long)

--- a/src/main/kotlin/dev/concert/domain/service/reservation/publisher/ReservationEventPublisher.kt
+++ b/src/main/kotlin/dev/concert/domain/service/reservation/publisher/ReservationEventPublisher.kt
@@ -1,0 +1,7 @@
+package dev.concert.domain.service.reservation.publisher
+
+import dev.concert.domain.service.reservation.event.ReservationSuccessEvent
+
+interface ReservationEventPublisher {
+    fun publish(event : ReservationSuccessEvent)
+}

--- a/src/main/kotlin/dev/concert/infrastructure/core/reservation/ReservationEventPublisherImpl.kt
+++ b/src/main/kotlin/dev/concert/infrastructure/core/reservation/ReservationEventPublisherImpl.kt
@@ -1,0 +1,21 @@
+package dev.concert.infrastructure.core.reservation
+
+import dev.concert.domain.service.reservation.event.ReservationSuccessEvent
+import dev.concert.domain.service.reservation.publisher.ReservationEventPublisher
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+class ReservationEventPublisherImpl (
+    private val applicationEventPublisher: ApplicationEventPublisher,
+) : ReservationEventPublisher{
+
+    private val log : Logger = LoggerFactory.getLogger(ReservationEventPublisherImpl::class.java)
+
+    override fun publish(event: ReservationSuccessEvent) {
+        applicationEventPublisher.publishEvent(event)
+        log.info("예약 성공 이벤트 발행")
+    }
+}

--- a/src/main/kotlin/dev/concert/infrastructure/slack/SlackApiClient.kt
+++ b/src/main/kotlin/dev/concert/infrastructure/slack/SlackApiClient.kt
@@ -1,0 +1,22 @@
+package dev.concert.infrastructure.slack
+
+import com.slack.api.Slack
+import dev.concert.domain.service.data.message.MessageManager
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class SlackApiClient : MessageManager {
+
+    private val log : Logger = LoggerFactory.getLogger(SlackApiClient::class.java)
+
+    override fun sendMessage() {
+        val client = Slack.getInstance().methods()
+        runCatching {
+            //TODO 슬랙 API 메시지 구성
+        }.onFailure { e ->
+            log.error("슬랙 메세지 전송 실패", e)
+        }
+    }
+}

--- a/src/main/kotlin/dev/concert/infrastructure/slack/SlackApiClient.kt
+++ b/src/main/kotlin/dev/concert/infrastructure/slack/SlackApiClient.kt
@@ -4,19 +4,29 @@ import com.slack.api.Slack
 import dev.concert.domain.service.data.message.MessageManager
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
 @Component
 class SlackApiClient : MessageManager {
 
+    @Value("\${slack.token}")
+    lateinit var token : String
+
+    @Value("\${slack.channel.id}")
+    lateinit var channelId : String
+
     private val log : Logger = LoggerFactory.getLogger(SlackApiClient::class.java)
 
-    override fun sendMessage() {
+    override fun sendMessage(message : String) {
         val client = Slack.getInstance().methods()
-        runCatching {
-            //TODO 슬랙 API 메시지 구성
-        }.onFailure { e ->
-            log.error("슬랙 메세지 전송 실패", e)
+
+        client.chatPostMessage {
+            it.token(token)
+                .channel(channelId)
+                .text(message)
         }
+
+        log.info("슬랙 메세지 전송 완료")
     }
 }

--- a/src/main/kotlin/dev/concert/interfaces/event/ReservationEventListener.kt
+++ b/src/main/kotlin/dev/concert/interfaces/event/ReservationEventListener.kt
@@ -1,0 +1,20 @@
+package dev.concert.interfaces.event
+
+import dev.concert.application.data.DataPlatformFacade
+import dev.concert.domain.service.reservation.event.ReservationSuccessEvent
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class ReservationEventListener (
+    private val dataPlatformFacade: DataPlatformFacade,
+) {
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handleExternalApiEvent(event: ReservationSuccessEvent) {
+        dataPlatformFacade.sendReservationData(event.reservationId)
+    }
+}

--- a/src/main/kotlin/dev/concert/interfaces/event/ReservationEventListener.kt
+++ b/src/main/kotlin/dev/concert/interfaces/event/ReservationEventListener.kt
@@ -2,6 +2,8 @@ package dev.concert.interfaces.event
 
 import dev.concert.application.data.DataPlatformFacade
 import dev.concert.domain.service.reservation.event.ReservationSuccessEvent
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
@@ -12,9 +14,16 @@ class ReservationEventListener (
     private val dataPlatformFacade: DataPlatformFacade,
 ) {
 
+    private val log : Logger = LoggerFactory.getLogger(ReservationEventListener::class.java)
+
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun handleExternalApiEvent(event: ReservationSuccessEvent) {
-        dataPlatformFacade.sendReservationData(event.reservationId)
+        runCatching {
+            dataPlatformFacade.sendReservationData(event.reservationId)
+        }.onFailure { ex ->
+            // 예외 처리 로직
+            log.error("데이터 플랫폼 전송 에러 : ${ex.message}", ex)
+        }
     }
 }


### PR DESCRIPTION
# 이벤트 발행을 통한 설계

interfaces : 리스너
application : 외부 api 처리 파사드
domain : 이벤트
infrastructure : 슬랙 메시지 구현

계층 구조를 통해 슬랙이 아니라 다른 외부 API 여도 domain 로직이 영향을 받지 않도록 DIP 를 지키면서 구현했습니다.
이번 설계의 핵심인 이벤트 발행과 이벤트 리스너의 로직이 실패하여도 메인 비즈니스 로직에 실패하지 않도록 구현하였고 결과도 설계 문서에 기록했습니다.
