### PR TITLE
[Index] 조회로직시 필요한 인덱스 추가

### DIFF
--- a/src/main/kotlin/dev/concert/domain/entity/ConcertEntity.kt
+++ b/src/main/kotlin/dev/concert/domain/entity/ConcertEntity.kt
@@ -8,7 +8,7 @@ import jakarta.persistence.Index
 import jakarta.persistence.Table
 
 @Entity
-@Table(name = "concert" , indexes = [Index(name = "idx_start_date", columnList = "startDate")])
+@Table(name = "concert" , indexes = [Index(name = "idx_start_date", columnList = "startDate")]) 
 class ConcertEntity(
     concertName: String,
     singer: String,

--- a/src/main/kotlin/dev/concert/domain/entity/ConcertOptionEntity.kt
+++ b/src/main/kotlin/dev/concert/domain/entity/ConcertOptionEntity.kt
@@ -13,10 +13,10 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 
 @Entity
-@Table(
-    name = "concert_option",
-    indexes = [Index(name = "idx_concert_id", columnList = "concert_id")]
-)
+@Table( 
+    name = "concert_option", 
+    indexes = [Index(name = "idx_concert_id", columnList = "concert_id")] 
+) 
 class ConcertOptionEntity(
     concert: ConcertEntity,
     availableSeats: Int,

--- a/src/main/kotlin/dev/concert/domain/entity/ReservationEntity.kt
+++ b/src/main/kotlin/dev/concert/domain/entity/ReservationEntity.kt
@@ -18,7 +18,7 @@ import jakarta.persistence.Table
 import java.time.LocalDateTime
 
 @Entity
-@Table(name = "reservation", indexes = [Index(name = "idx_expires_at", columnList = "expires_at")])
+@Table(name = "reservation", indexes = [Index(name = "idx_expires_at", columnList = "expires_at")]) 
 class ReservationEntity(
     user: UserEntity,
     seat : SeatEntity,

--- a/src/main/kotlin/dev/concert/domain/entity/SeatEntity.kt
+++ b/src/main/kotlin/dev/concert/domain/entity/SeatEntity.kt
@@ -17,10 +17,10 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 
 @Entity
-@Table(
-    name = "seat",
-    indexes = [Index(name = "idx_seat_status_concert_option_id", columnList = "seat_status,concert_option_id")]
-)
+@Table( 
+    name = "seat", 
+    indexes = [Index(name = "idx_seat_status_concert_option_id", columnList = "seat_status,concert_option_id")] 
+) 
 class SeatEntity(
     concertOption: ConcertOptionEntity,
     price: Long,


### PR DESCRIPTION
# 엔덱스 추가

1. 콘서트 목록 조회
2. 콘서트 옵션 조회
3. 좌석조회
4. 예약조회 (스케줄러)

문서상에는 1,2,3 번이 적혀있지만 1번과 4번의 쿼리가 전부 부등호 (>) 를 사용하는 쿼리여서 1번 콘서트 목록 조회로 문서를 작성 했습니다.